### PR TITLE
TRC-36-feat: add FeedItem component

### DIFF
--- a/apps/web/src/components/FeedItem/FeedItem.scss
+++ b/apps/web/src/components/FeedItem/FeedItem.scss
@@ -1,0 +1,24 @@
+.feedsbar-feeditem-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 10px;
+  gap: 10px;
+}
+
+.feedsbar-feeditem-label {
+  font-family: Verdana;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 19px;
+  letter-spacing: 0em;
+  text-align: left;
+  color: #000000;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+// Remove default underline style for anchor tag link (note: tried applying this style in .feedsbar-feeditem-label and elsewhere but it would not override the style below, even with !important)
+a:-webkit-any-link {
+  text-decoration: none;
+}

--- a/apps/web/src/components/FeedItem/FeedItem.scss
+++ b/apps/web/src/components/FeedItem/FeedItem.scss
@@ -9,6 +9,7 @@ a:-webkit-any-link {
   align-items: center;
   padding: 10px;
   gap: 10px;
+  height: 100%;
 }
 
 .feedsbar-feeditem-label {

--- a/apps/web/src/components/FeedItem/FeedItem.scss
+++ b/apps/web/src/components/FeedItem/FeedItem.scss
@@ -1,3 +1,8 @@
+a,
+a:-webkit-any-link {
+  text-decoration: none;
+}
+
 .feedsbar-feeditem-container {
   display: flex;
   flex-direction: row;
@@ -16,9 +21,4 @@
   color: #000000;
   text-decoration: none;
   cursor: pointer;
-}
-
-// Remove default underline style for anchor tag link (note: tried applying this style in .feedsbar-feeditem-label and elsewhere but it would not override the style below, even with !important)
-a:-webkit-any-link {
-  text-decoration: none;
 }

--- a/apps/web/src/components/FeedItem/FeedItem.stories.tsx
+++ b/apps/web/src/components/FeedItem/FeedItem.stories.tsx
@@ -9,7 +9,9 @@ export default {
 } as ComponentMeta<typeof FeedItem>;
 
 const Template: ComponentStory<typeof FeedItem> = (args) => (
-  <FeedItem {...args} />
+  <div style={{ height: '35px' }}>
+    <FeedItem {...args} />
+  </div>
 );
 
 export const Default = Template.bind({});

--- a/apps/web/src/components/FeedItem/FeedItem.stories.tsx
+++ b/apps/web/src/components/FeedItem/FeedItem.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import FeedItem, { Props } from './FeedItem';
+import FeedItem from './FeedItem';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ReactComponent as HomeIcon } from '../../assets/homeIcon.svg';
 
@@ -8,7 +8,7 @@ export default {
   component: FeedItem,
 } as ComponentMeta<typeof FeedItem>;
 
-const Template: ComponentStory<typeof FeedItem> = (args: Props) => (
+const Template: ComponentStory<typeof FeedItem> = (args) => (
   <FeedItem {...args} />
 );
 

--- a/apps/web/src/components/FeedItem/FeedItem.stories.tsx
+++ b/apps/web/src/components/FeedItem/FeedItem.stories.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import FeedItem, { Props } from './FeedItem';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ReactComponent as HomeIcon } from '../../assets/homeIcon.svg';
+
+export default {
+  title: 'Components/FeedItem',
+  component: FeedItem,
+} as ComponentMeta<typeof FeedItem>;
+
+const Template: ComponentStory<typeof FeedItem> = (args: Props) => (
+  <FeedItem {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  svg: <HomeIcon />,
+  label: 'Home',
+  href: '',
+};

--- a/apps/web/src/components/FeedItem/FeedItem.test.tsx
+++ b/apps/web/src/components/FeedItem/FeedItem.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import FeedItem, { Props } from './FeedItem';
+import { ReactComponent as HomeIcon } from '../../assets/homeIcon.svg';
+
+describe('FeedItem component', () => {
+  const defaultProps: Props = {
+    svg: <HomeIcon />,
+    label: 'Home',
+    href: '',
+  };
+
+  it('renders the SVG icon and label and checks that both are in the document', () => {
+    render(<FeedItem {...defaultProps} />);
+    expect(screen.getByTestId('Home')).toBeInTheDocument();
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('renders an anchor tag with the correct href', () => {
+    render(<FeedItem {...defaultProps} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '');
+  });
+});

--- a/apps/web/src/components/FeedItem/FeedItem.tsx
+++ b/apps/web/src/components/FeedItem/FeedItem.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Icon, { iconColor } from '../Icon/Icon';
+import './FeedItem.scss';
+
+export interface Props {
+  svg: React.ReactElement;
+  label: string;
+  href: string;
+}
+
+/**
+ * Renders a FeedItem component
+ *
+ * @param {Object} props - The props object.
+ * @param {React.ReactElement} props.svg - The SVG icon to display
+ * @param {string} props.label - The text to show in the label element.
+ * @param {string} props.href - the URL to use in the anchor element.
+ * @returns {JSX.Element} A JSX element
+ */
+const FeedItem = ({ svg, label, href }: Props) => {
+  return (
+    <a href={href}>
+      <div className="feedsbar-feeditem-container">
+        <Icon colorProp={iconColor.Default} customTestId={label}>
+          {svg}
+        </Icon>
+        <label className="feedsbar-feeditem-label">{label}</label>
+      </div>
+    </a>
+  );
+};
+
+export default FeedItem;

--- a/apps/web/src/components/FeedItem/FeedItem.tsx
+++ b/apps/web/src/components/FeedItem/FeedItem.tsx
@@ -11,7 +11,7 @@ export interface Props {
 /**
  * Renders a FeedItem component
  *
- * @param {Object} props - The props object.
+ * @param {Props} props - The props object.
  * @param {React.ReactElement} props.svg - The SVG icon to display
  * @param {string} props.label - The text to show in the label element.
  * @param {string} props.href - The URL to use in the anchor element.

--- a/apps/web/src/components/FeedItem/FeedItem.tsx
+++ b/apps/web/src/components/FeedItem/FeedItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Icon, { iconColor } from '../Icon/Icon';
 import './FeedItem.scss';
 
@@ -14,12 +14,12 @@ export interface Props {
  * @param {Object} props - The props object.
  * @param {React.ReactElement} props.svg - The SVG icon to display
  * @param {string} props.label - The text to show in the label element.
- * @param {string} props.href - the URL to use in the anchor element.
+ * @param {string} props.href - The URL to use in the anchor element.
  * @returns {JSX.Element} A JSX element
  */
 const FeedItem = ({ svg, label, href }: Props) => {
   return (
-    <a href={href}>
+    <a href={href} aria-label={label}>
       <div className="feedsbar-feeditem-container">
         <Icon colorProp={iconColor.Default} customTestId={label}>
           {svg}


### PR DESCRIPTION
# TL/DR
This story creates a FeedItem component to be used for navigation.

![FeedItem-Component](https://user-images.githubusercontent.com/40574120/230105573-52867c8e-9304-4307-8d30-cfdeb589fd76.jpg)

## Overview of Changes
`FeedItem.tsx`

- creates Props interface with `svg`, `label`, and `href`
- creates FeedItem component that accepts `svg`, `label`, and `href` as props to render an `<Icon />` component with a `label` to the right.

`FeedItem.scss`

- add scss file to style `FeedItem` component.

`FeedItem.stories.tsx`

- adds a default story with home icon, "Home" as the label prop, and `''` as href.

`FeedItem.test.tsx`

- Creates unit tests to ensure Icon and Label display in the document and verify that the href is passed correctly.