### PR TITLE
TRC-43- Add Global `Colors` Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,24 @@ In order to import our SVGs as React components, we uuse the ReactComponent impo
 
 To streamline the process of converting SVG icons to React components, we've included a script in our package.json file: `"build:svgs": "svgr --icon --out-dir src/assets"`. Running this script each time we add a new icon to our assets folder ensures that we don't forget to convert it and that we're always up-to-date with the latest icons in our application.
 
-=======
+### Global Theme / Color Scheme
+
+# Defining the Color Theme
+
+Create a `Colors.scss` file to define a set of colors that will be used throughout the project. Use the `:root` pseudo-class to define the list of colors in the `Colors.scss` file.
+
+# Defining Global Styles
+
+Create a `Global.scss` file to define global styles that will be used throughout the project. Import the Colors.scss file into the `Global.scss` file so that the color variables can be used in the global styles.
+
+# Importing Global Styles
+
+Import the `Global.scss` file into your main SCSS file so that the global styles are applied to the entire application. You can then simply use the css function `var()` to call the color you'd like to use. For example, `var(--black)`.
+
+# Using Storybook
+
+Global styles will not be applied to the Storybook stories by default.
+To make the global styles available in Storybook, add the import statement for the `Global.scss` file to the `preview.js` file in the Storybook configuration. This ensures that the stories are consistent with the rest of the application.
 
 # Back-End / API
 

--- a/apps/web/.storybook/GlobalDecorator.tsx
+++ b/apps/web/.storybook/GlobalDecorator.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
-import { addDecorator } from '@storybook/react';
 import '../src/Styles/Global.scss';
 
 const GlobalDecorator = (storyFn) => (
   <div className="global-wrapper">{storyFn()}</div>
 );
-
-addDecorator(GlobalDecorator);

--- a/apps/web/.storybook/GlobalDecorator.tsx
+++ b/apps/web/.storybook/GlobalDecorator.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { addDecorator } from '@storybook/react';
+import '../src/Styles/Global.scss';
+
+const GlobalDecorator = (storyFn) => (
+  <div className="global-wrapper">{storyFn()}</div>
+);
+
+addDecorator(GlobalDecorator);

--- a/apps/web/.storybook/preview.js
+++ b/apps/web/.storybook/preview.js
@@ -1,3 +1,8 @@
+import { configure } from '@storybook/react';
+import './GlobalDecorator';
+
+configure(require.context('../src', true, /\.stories\.ts$/), module);
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
@@ -6,4 +11,4 @@ export const parameters = {
       date: /Date$/,
     },
   },
-}
+};

--- a/apps/web/.storybook/preview.js
+++ b/apps/web/.storybook/preview.js
@@ -1,7 +1,4 @@
-import { configure } from '@storybook/react';
 import './GlobalDecorator';
-
-configure(require.context('../src', true, /\.stories\.ts$/), module);
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/apps/web/src/App.scss
+++ b/apps/web/src/App.scss
@@ -1,3 +1,5 @@
+@import './Styles/Global.scss';
+
 .App {
-	background-color: lightpink;
+  background-color: lightpink;
 }

--- a/apps/web/src/Styles/Colors.scss
+++ b/apps/web/src/Styles/Colors.scss
@@ -1,0 +1,17 @@
+:root {
+  /* Light Mode */
+  --black: #1c1c1c;
+  --blue: #3478cc;
+  --whitesmoke: #dbe0e5;
+  --gray: #888a8c;
+  --orange: #eb5428;
+  --white: #ffffff;
+
+  /* Dark Mode */
+  --black-dark: var(--white);
+  --blue-dark: var(--blue);
+  --whitesmoke-dark: var(--whitesmoke);
+  --gray-dark: var(--gray);
+  --orange-dark: var(--orange);
+  --white-dark: var(--black);
+}

--- a/apps/web/src/Styles/Colors.scss
+++ b/apps/web/src/Styles/Colors.scss
@@ -6,12 +6,4 @@
   --gray: #888a8c;
   --orange: #eb5428;
   --white: #ffffff;
-
-  /* Dark Mode */
-  --black-dark: var(--white);
-  --blue-dark: var(--blue);
-  --whitesmoke-dark: var(--whitesmoke);
-  --gray-dark: var(--gray);
-  --orange-dark: var(--orange);
-  --white-dark: var(--black);
 }

--- a/apps/web/src/Styles/Global.scss
+++ b/apps/web/src/Styles/Global.scss
@@ -1,0 +1,5 @@
+@import './Colors.scss';
+
+body {
+  background-color: var(--white);
+}

--- a/apps/web/src/components/SearchBar/SearchBar.scss
+++ b/apps/web/src/components/SearchBar/SearchBar.scss
@@ -30,7 +30,7 @@ input {
 }
 
 input:hover {
-  outline: 0.125rem solid '#3478cc';
+  outline: 0.125rem solid #3478cc;
 }
 
 input:focus {

--- a/apps/web/src/components/SearchBar/SearchBar.scss
+++ b/apps/web/src/components/SearchBar/SearchBar.scss
@@ -30,7 +30,7 @@ input {
 }
 
 input:hover {
-  outline: 0.125rem solid #3478cc;
+  outline: 0.125rem solid '#3478cc';
 }
 
 input:focus {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,13 +1,13 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }


### PR DESCRIPTION
## TL/DR
This story involves creating a global color theme to keep our project's theme consistent.

## Overview of Changes

`Colors.scss`
- Declare our color scheme with a light & dark mode.

`Global.scss`
- Add `Global.scss` and import our `Colors.scss` to make declared colors available globally

`App.scss`
- Import `Global.scss` into projects main css file. 

`GlobalDecorator.tsx `
- Wraps stories with the global css file that we have imported.

`preview.js`
- Configures the decorator that wraps each Storybook story, giving the story access to the global colors without having to import them in each story individually.

`read.me`
- Updated docs 