### PR TITLE
TRC-47 - Fix: prop filterResults error within Searchbar

### DIFF
--- a/apps/web/src/components/SearchBar/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar/SearchBar.tsx
@@ -23,7 +23,7 @@ export interface Props {
  */
 const SearchBar = ({
   handleSearch,
-  filterResults,
+  filterResults = () => [],
   customTestId = 'searchbar',
 }: Props): React.ReactElement => {
   /** references input element */
@@ -52,7 +52,7 @@ const SearchBar = ({
   const handleOnChange = (): void => {
     const searchString = ref.current?.value;
     if (!!searchString) {
-      //  filterResults(searchString);
+      filterResults(searchString);
     }
   };
 


### PR DESCRIPTION
TL/DR
This story involves fixing an error that the filterResults function was causing when values were entered into the input of the searchbar.

Overview of Changes

`SearchBar.tsx`
A default value was given to the funtion within the paremeter of the `searchBar` function. We were trying to call an undefined function, and with the default parameter we at least have a function that returns an empty array.