### PR TITLE
TRC-52 - feat: add `TrendingSuggestions` component

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,11 @@
     "build-storybook": "build-storybook -s public",
     "build:svgs": "svgr --icon --out-dir src/assets"
   },
+  "jest": {
+    "moduleNameMapper": {
+      "axios": "axios/dist/node/axios.cjs"
+    }
+  },
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.2",
     "@storybook/addon-a11y": "^6.5.16",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import './App.scss';
+import TrendingSuggestions from './components/TrendingSuggestions/TrendingSuggestions';
 
 const App = (): React.ReactElement => {
   return (
     <div className="App">
       <h1>Reddit Clone</h1>
+      <TrendingSuggestions />
     </div>
   );
 };

--- a/apps/web/src/components/TrendingItemSuggestion/TrendingItemSuggestion.tsx
+++ b/apps/web/src/components/TrendingItemSuggestion/TrendingItemSuggestion.tsx
@@ -55,10 +55,6 @@ const TrendingItemSuggestion = ({
             </div>
             <h2 data-testid="list-item-summary">{trendingSuggestionSummary}</h2>
             <div className="list-item-target-subreddit">
-              {/* <Icon customTestId="list-item-subreddit-icon">
-                
-                {subRedditIcon}
-              </Icon> */}
               <p>{subRedditIcon}</p>
               <p data-testid="list-item-subreddit-link">{subRedditName}</p>
             </div>

--- a/apps/web/src/components/TrendingItemSuggestion/TrendingItemSuggestion.tsx
+++ b/apps/web/src/components/TrendingItemSuggestion/TrendingItemSuggestion.tsx
@@ -10,7 +10,7 @@ interface Props {
     trendingSuggestionHeading: string;
     trendingSuggestionSummary: string;
     targetSubreddit: {
-      subRedditIcon: React.ReactElement;
+      subRedditIcon: string;
       subRedditName: string;
     };
   };
@@ -53,14 +53,13 @@ const TrendingItemSuggestion = ({
                 {trendingSuggestionHeading}
               </h1>
             </div>
-            <h2 data-testid="list-item-summary">
-              {' '}
-              {trendingSuggestionSummary}
-            </h2>
+            <h2 data-testid="list-item-summary">{trendingSuggestionSummary}</h2>
             <div className="list-item-target-subreddit">
-              <Icon customTestId="list-item-subreddit-icon">
+              {/* <Icon customTestId="list-item-subreddit-icon">
+                
                 {subRedditIcon}
-              </Icon>
+              </Icon> */}
+              <p>{subRedditIcon}</p>
               <p data-testid="list-item-subreddit-link">{subRedditName}</p>
             </div>
           </div>

--- a/apps/web/src/components/TrendingItemSuggestion/TrendingItemSuggestion.utils.tsx
+++ b/apps/web/src/components/TrendingItemSuggestion/TrendingItemSuggestion.utils.tsx
@@ -1,16 +1,9 @@
-import Icon from '../Icon/Icon';
-import { ReactComponent as ReactIcon } from '../../assets/reactSubRedditIcon.svg';
-
 export const metaData = {
   URL: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTB8fGNvZGV8ZW58MHx8MHx8&w=1000&q=80',
   trendingSuggestionHeading: 'Search Preview Item Heading',
   trendingSuggestionSummary: 'Search Preview Item Summary',
   targetSubreddit: {
-    subRedditIcon: (
-      <Icon>
-        <ReactIcon />
-      </Icon>
-    ),
+    subRedditIcon: 'temp',
     subRedditName: 'r/SubbreditLink',
   },
 };

--- a/apps/web/src/components/TrendingSuggestionList/TrendingSuggestionList.tsx
+++ b/apps/web/src/components/TrendingSuggestionList/TrendingSuggestionList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import TrendingItemSuggestion from '../TrendingItemSuggestion/TrendingItemSuggestion';
 import './TrendingSuggestionList.scss';
 
-interface MetaDataItem {
+export interface MetaDataItem {
   /** How can we view the suggested post? */
   URL: string;
   /** Suggestion Title */
@@ -12,7 +12,7 @@ interface MetaDataItem {
   /** Specific forum the suggestion lives in */
   targetSubreddit: {
     /** Forum's Icon */
-    subRedditIcon: React.ReactElement;
+    subRedditIcon: string;
     /** Forum's title */
     subRedditName: string;
   };

--- a/apps/web/src/components/TrendingSuggestionList/TrendingSuggestionList.utils.tsx
+++ b/apps/web/src/components/TrendingSuggestionList/TrendingSuggestionList.utils.tsx
@@ -1,17 +1,10 @@
-import Icon from '../Icon/Icon';
-import { ReactComponent as ReactIcon } from '../../assets/reactSubRedditIcon.svg';
-
 export const metaDataItems = [
   {
     URL: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTB8fGNvZGV8ZW58MHx8MHx8&w=1000&q=80',
     trendingSuggestionHeading: 'Search Preview Item Heading',
     trendingSuggestionSummary: 'Search Preview Item Summary',
     targetSubreddit: {
-      subRedditIcon: (
-        <Icon>
-          <ReactIcon />
-        </Icon>
-      ),
+      subRedditIcon: 'temp',
       subRedditName: 'r/SubbreditLink',
     },
   },
@@ -20,11 +13,7 @@ export const metaDataItems = [
     trendingSuggestionHeading: 'Search Preview Item Heading',
     trendingSuggestionSummary: 'Search Preview Item Summary',
     targetSubreddit: {
-      subRedditIcon: (
-        <Icon>
-          <ReactIcon />
-        </Icon>
-      ),
+      subRedditIcon: 'temp',
       subRedditName: 'r/SubbreditLink',
     },
   },
@@ -33,11 +22,7 @@ export const metaDataItems = [
     trendingSuggestionHeading: 'Search Preview Item Heading',
     trendingSuggestionSummary: 'Search Preview Item Summary',
     targetSubreddit: {
-      subRedditIcon: (
-        <Icon>
-          <ReactIcon />
-        </Icon>
-      ),
+      subRedditIcon: 'temp',
       subRedditName: 'r/SubbreditLink',
     },
   },

--- a/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.api.ts
+++ b/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.api.ts
@@ -4,10 +4,8 @@ import axios from 'axios';
 const fetchTrendingSuggestions = async () => {
   try {
     const response = await axios.get('/trending-suggestions');
-    console.log(response.data);
     return response.data;
   } catch (error) {
-    console.log(error);
     return error;
   }
 };

--- a/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.api.ts
+++ b/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.api.ts
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import axios from 'axios';
+
+const fetchTrendingSuggestions = async () => {
+  try {
+    const response = await axios.get('/trending-suggestions');
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.log(error);
+    return error;
+  }
+};
+
+export default fetchTrendingSuggestions;

--- a/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.test.tsx
+++ b/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.test.tsx
@@ -1,0 +1,80 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { render, waitFor, screen } from '@testing-library/react';
+import TrendingSuggestions from './TrendingSuggestions';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+const queryClient = new QueryClient();
+
+const server = setupServer(
+  rest.get('trending-suggestions', (req, res, ctx) => {
+    return res(
+      ctx.json([
+        {
+          URL: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTB8fGNvZGV8ZW58MHx8MHx8&w=1000&q=80',
+          trendingSuggestionHeading: 'Search Preview Item Heading 1',
+          trendingSuggestionSummary: 'Search Preview Item Summary',
+          targetSubreddit: {
+            subRedditIcon: 'temp',
+            subRedditName: 'r/SubbreditLink',
+          },
+        },
+        {
+          URL: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTB8fGNvZGV8ZW58MHx8MHx8&w=1000&q=80',
+          trendingSuggestionHeading: 'Search Preview Item Heading 2',
+          trendingSuggestionSummary: 'Search Preview Item Summary',
+          targetSubreddit: {
+            subRedditIcon: 'temp',
+            subRedditName: 'r/SubbreditLink',
+          },
+        },
+        {
+          URL: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTB8fGNvZGV8ZW58MHx8MHx8&w=1000&q=80',
+          trendingSuggestionHeading: 'Search Preview Item Heading 3',
+          trendingSuggestionSummary: 'Search Preview Item Summary',
+          targetSubreddit: {
+            subRedditIcon: 'temp',
+            subRedditName: 'r/SubbreditLink',
+          },
+        },
+      ])
+    );
+  })
+);
+
+const QueriedComponent = () => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TrendingSuggestions />
+    </QueryClientProvider>
+  );
+};
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('TrendingSuggestionList', () => {
+  it('should render data correctly', async () => {
+    render(<QueriedComponent />);
+
+    // Wait for data to be fetched and rendered
+    await waitFor(() => {
+      expect(
+        screen.getByText('Search Preview Item Heading 1')
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Search Preview Item Heading 2')
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Search Preview Item Heading 3')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.test.tsx
+++ b/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.test.tsx
@@ -1,17 +1,8 @@
-import { render, waitFor, screen } from '@testing-library/react';
-import TrendingSuggestions from './TrendingSuggestions';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { waitFor, screen } from '@testing-library/react';
 import server from '../../mocks/mockServer';
-
-const queryClient = new QueryClient();
-
-const QueriedComponent = () => {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <TrendingSuggestions />
-    </QueryClientProvider>
-  );
-};
+import { render } from '../../test/testSetup';
+import TrendingSuggestions from './TrendingSuggestions';
+import TestProviders from '../../test/testSetup';
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
@@ -19,7 +10,7 @@ afterAll(() => server.close());
 
 describe('TrendingSuggestionList', () => {
   it('should render data correctly', async () => {
-    render(<QueriedComponent />);
+    render(<TrendingSuggestions />, { wrapper: TestProviders });
 
     // Wait for data to be fetched and rendered
     await waitFor(() => {

--- a/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.test.tsx
+++ b/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.test.tsx
@@ -1,46 +1,9 @@
-import { rest } from 'msw';
-import { setupServer } from 'msw/node';
 import { render, waitFor, screen } from '@testing-library/react';
 import TrendingSuggestions from './TrendingSuggestions';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import server from '../../mocks/mockServer';
 
 const queryClient = new QueryClient();
-
-const server = setupServer(
-  rest.get('trending-suggestions', (req, res, ctx) => {
-    return res(
-      ctx.json([
-        {
-          URL: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTB8fGNvZGV8ZW58MHx8MHx8&w=1000&q=80',
-          trendingSuggestionHeading: 'Search Preview Item Heading 1',
-          trendingSuggestionSummary: 'Search Preview Item Summary',
-          targetSubreddit: {
-            subRedditIcon: 'temp',
-            subRedditName: 'r/SubbreditLink',
-          },
-        },
-        {
-          URL: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTB8fGNvZGV8ZW58MHx8MHx8&w=1000&q=80',
-          trendingSuggestionHeading: 'Search Preview Item Heading 2',
-          trendingSuggestionSummary: 'Search Preview Item Summary',
-          targetSubreddit: {
-            subRedditIcon: 'temp',
-            subRedditName: 'r/SubbreditLink',
-          },
-        },
-        {
-          URL: 'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTB8fGNvZGV8ZW58MHx8MHx8&w=1000&q=80',
-          trendingSuggestionHeading: 'Search Preview Item Heading 3',
-          trendingSuggestionSummary: 'Search Preview Item Summary',
-          targetSubreddit: {
-            subRedditIcon: 'temp',
-            subRedditName: 'r/SubbreditLink',
-          },
-        },
-      ])
-    );
-  })
-);
 
 const QueriedComponent = () => {
   return (
@@ -60,21 +23,8 @@ describe('TrendingSuggestionList', () => {
 
     // Wait for data to be fetched and rendered
     await waitFor(() => {
-      expect(
-        screen.getByText('Search Preview Item Heading 1')
-      ).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('Search Preview Item Heading 2')
-      ).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('Search Preview Item Heading 3')
-      ).toBeInTheDocument();
+      const headings = screen.getAllByText('Search Preview Item Heading');
+      expect(headings).toHaveLength(3);
     });
   });
 });

--- a/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.tsx
+++ b/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.tsx
@@ -6,14 +6,12 @@ import TrendingSuggestionList from '../TrendingSuggestionList/TrendingSuggestion
 const TrendingSuggestions = () => {
   const { data, isLoading } = useQuery(
     ['trending-suggestions'],
-    () => {
-      const response = fetchTrendingSuggestions();
-      return response;
-    },
+    () => fetchTrendingSuggestions(),
     { staleTime: Infinity }
   );
 
   // placeholder func, will be removed when we add react router + refactor
+  // ticket: https://github.com/users/wijohnst/projects/10/views/1?pane=issue&itemId=27392872
   const handleClick = () => {
     console.log('temp');
   };

--- a/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.tsx
+++ b/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { useQuery } from 'react-query';
+import fetchTrendingSuggestions from './TrendingSuggestions.api';
+import TrendingSuggestionList from '../TrendingSuggestionList/TrendingSuggestionList';
+
+const TrendingSuggestions = () => {
+  const { data, isLoading } = useQuery(
+    ['trending-suggestions'],
+    () => {
+      const response = fetchTrendingSuggestions();
+      return response;
+    },
+    { staleTime: Infinity }
+  );
+
+  // placeholder func, will be removed when we add react router + refactor
+  const handleClick = () => {
+    console.log('temp');
+  };
+
+  return (
+    <>
+      {data && (
+        <TrendingSuggestionList
+          metaDataItems={data}
+          isLoading={isLoading}
+          handleClick={handleClick}
+        />
+      )}
+    </>
+  );
+};
+
+export default TrendingSuggestions;

--- a/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.tsx
+++ b/apps/web/src/components/TrendingSuggestions/TrendingSuggestions.tsx
@@ -20,13 +20,11 @@ const TrendingSuggestions = () => {
 
   return (
     <>
-      {data && (
-        <TrendingSuggestionList
-          metaDataItems={data}
-          isLoading={isLoading}
-          handleClick={handleClick}
-        />
-      )}
+      <TrendingSuggestionList
+        metaDataItems={data}
+        isLoading={isLoading}
+        handleClick={handleClick}
+      />
     </>
   );
 };

--- a/apps/web/src/mocks/mockServer.ts
+++ b/apps/web/src/mocks/mockServer.ts
@@ -1,0 +1,11 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/lib/node';
+import { metaData } from '../components/TrendingItemSuggestion/TrendingItemSuggestion.utils';
+
+const server = setupServer(
+  rest.get('trending-suggestions', (req, res, ctx) => {
+    return res(ctx.json([metaData, metaData, metaData]));
+  })
+);
+
+export default server;

--- a/apps/web/src/setupTests.ts
+++ b/apps/web/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import "@testing-library/jest-dom";
+import '@testing-library/jest-dom';

--- a/apps/web/src/test/testSetup.tsx
+++ b/apps/web/src/test/testSetup.tsx
@@ -1,0 +1,20 @@
+import React, { ReactElement } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+const queryClient = new QueryClient();
+
+const TestProviders: React.FC = ({ children }) => {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const customRender = (
+  ui: ReactElement,
+  options?: RenderOptions & { wrapper?: React.ComponentType }
+) => render(ui, { wrapper: TestProviders, ...options });
+
+export * from '@testing-library/react';
+export { customRender as render };
+export default TestProviders;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,23 +225,30 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.18.6
+    dev: true
 
-  /@babel/compat-data/7.20.14:
-    resolution: {integrity: sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==}
+  /@babel/code-frame/7.21.4:
+    resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.18.6
+
+  /@babel/compat-data/7.21.4:
+    resolution: {integrity: sha512-/DYyDpeCfaVinT40FPGdkkb+lYSKvsVuMjDAG7jPOWWiM1ibOaB9CXJAlc4d1QpP/U2q2P9jbrSlClKSErd55g==}
     engines: {node: '>=6.9.0'}
 
   /@babel/core/7.12.9:
     resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-module-transforms': 7.20.11
+      '@babel/code-frame': 7.21.4
+      '@babel/generator': 7.21.4
+      '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.20.13
-      '@babel/parser': 7.20.15
+      '@babel/parser': 7.21.4
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -259,15 +266,15 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
-      '@babel/helper-module-transforms': 7.20.11
+      '@babel/code-frame': 7.21.4
+      '@babel/generator': 7.21.4
+      '@babel/helper-compilation-targets': 7.21.4_@babel+core@7.20.12
+      '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.20.13
-      '@babel/parser': 7.20.15
+      '@babel/parser': 7.21.4
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -289,42 +296,43 @@ packages:
       eslint-visitor-keys: 2.1.0
       semver: 6.3.0
 
-  /@babel/generator/7.20.14:
-    resolution: {integrity: sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==}
+  /@babel/generator/7.21.4:
+    resolution: {integrity: sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
       '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
 
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.18.9:
     resolution: {integrity: sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
-  /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.12:
-    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
+  /@babel/helper-compilation-targets/7.21.4_@babel+core@7.20.12:
+    resolution: {integrity: sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.21.4
       '@babel/core': 7.20.12
-      '@babel/helper-validator-option': 7.18.6
+      '@babel/helper-validator-option': 7.21.0
       browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
 
-  /@babel/helper-create-class-features-plugin/7.20.12_@babel+core@7.20.12:
-    resolution: {integrity: sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==}
+  /@babel/helper-create-class-features-plugin/7.21.4_@babel+core@7.20.12:
+    resolution: {integrity: sha512-46QrX2CQlaFRF4TkwfTt6nJD7IHq8539cCL7SDpqWSDeJKY1xylKKY5F/33mJhLZ3mFvKv2gGrVS6NkyF6qs+Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -332,8 +340,8 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-member-expression-to-functions': 7.20.7
+      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-member-expression-to-functions': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/helper-replace-supers': 7.20.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
@@ -357,10 +365,10 @@ packages:
       '@babel/core': ^7.4.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/helper-compilation-targets': 7.21.4_@babel+core@7.20.12
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.21.4
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.1
@@ -375,7 +383,7 @@ packages:
       '@babel/core': ^7.4.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/helper-compilation-targets': 7.21.4_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -392,35 +400,35 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
-  /@babel/helper-function-name/7.19.0:
-    resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
+  /@babel/helper-function-name/7.21.0:
+    resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
-  /@babel/helper-member-expression-to-functions/7.20.7:
-    resolution: {integrity: sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==}
+  /@babel/helper-member-expression-to-functions/7.21.0:
+    resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
-  /@babel/helper-module-transforms/7.20.11:
-    resolution: {integrity: sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==}
+  /@babel/helper-module-transforms/7.21.2:
+    resolution: {integrity: sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.9
@@ -429,8 +437,8 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
     transitivePeerDependencies:
       - supports-color
 
@@ -438,7 +446,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@babel/helper-plugin-utils/7.10.4:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
@@ -458,7 +466,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
     transitivePeerDependencies:
       - supports-color
 
@@ -467,11 +475,11 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-member-expression-to-functions': 7.20.7
+      '@babel/helper-member-expression-to-functions': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
     transitivePeerDependencies:
       - supports-color
 
@@ -479,19 +487,19 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@babel/helper-skip-transparent-expression-wrappers/7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
@@ -501,18 +509,18 @@ packages:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-validator-option/7.18.6:
-    resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
+  /@babel/helper-validator-option/7.21.0:
+    resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-wrap-function/7.20.5:
     resolution: {integrity: sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-function-name': 7.21.0
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
     transitivePeerDependencies:
       - supports-color
 
@@ -521,8 +529,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
     transitivePeerDependencies:
       - supports-color
 
@@ -539,7 +547,14 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
+
+  /@babel/parser/7.21.4:
+    resolution: {integrity: sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.21.4
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -559,7 +574,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.20.12
 
   /@babel/plugin-proposal-async-generator-functions/7.20.7_@babel+core@7.20.12:
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
@@ -582,19 +597,19 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.21.4_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/plugin-proposal-class-static-block/7.20.7_@babel+core@7.20.12:
-    resolution: {integrity: sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==}
+  /@babel/plugin-proposal-class-static-block/7.21.0_@babel+core@7.20.12:
+    resolution: {integrity: sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.21.4_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.20.12
     transitivePeerDependencies:
@@ -607,7 +622,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.21.4_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-replace-supers': 7.20.7
       '@babel/helper-split-export-declaration': 7.18.6
@@ -692,9 +707,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.9
-      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.12.9
+      '@babel/plugin-transform-parameters': 7.21.3_@babel+core@7.12.9
     dev: true
 
   /@babel/plugin-proposal-object-rest-spread/7.20.7_@babel+core@7.20.12:
@@ -703,12 +718,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.21.4
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/helper-compilation-targets': 7.21.4_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-transform-parameters': 7.21.3_@babel+core@7.20.12
 
   /@babel/plugin-proposal-optional-catch-binding/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
@@ -720,8 +735,8 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.20.12
 
-  /@babel/plugin-proposal-optional-chaining/7.20.7_@babel+core@7.20.12:
-    resolution: {integrity: sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==}
+  /@babel/plugin-proposal-optional-chaining/7.21.0_@babel+core@7.20.12:
+    resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -738,20 +753,20 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.21.4_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/plugin-proposal-private-property-in-object/7.20.5_@babel+core@7.20.12:
-    resolution: {integrity: sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==}
+  /@babel/plugin-proposal-private-property-in-object/7.21.0_@babel+core@7.20.12:
+    resolution: {integrity: sha512-ha4zfehbJjc5MmXBlHec1igel5TJXXLDDRbuJ4+XT2TJcyD9/V1919BA8gMvsdHcNMBy4WBUBiRb3nw/EQUtBw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.21.4_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.20.12
     transitivePeerDependencies:
@@ -878,8 +893,8 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+  /@babel/plugin-syntax-jsx/7.21.4_@babel+core@7.20.12:
+    resolution: {integrity: sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1002,8 +1017,8 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-block-scoping/7.20.15_@babel+core@7.20.12:
-    resolution: {integrity: sha512-Vv4DMZ6MiNOhu/LdaZsT/bsLRxgL94d269Mv4R/9sp6+Mp++X/JqypZYypJXLlM4mlL352/Egzbzr98iABH1CA==}
+  /@babel/plugin-transform-block-scoping/7.21.0_@babel+core@7.20.12:
+    resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1011,17 +1026,17 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-classes/7.20.7_@babel+core@7.20.12:
-    resolution: {integrity: sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==}
+  /@babel/plugin-transform-classes/7.21.0_@babel+core@7.20.12:
+    resolution: {integrity: sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/helper-compilation-targets': 7.21.4_@babel+core@7.20.12
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-function-name': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-replace-supers': 7.20.7
@@ -1040,8 +1055,8 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/template': 7.20.7
 
-  /@babel/plugin-transform-destructuring/7.20.7_@babel+core@7.20.12:
-    resolution: {integrity: sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==}
+  /@babel/plugin-transform-destructuring/7.21.3_@babel+core@7.20.12:
+    resolution: {integrity: sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1088,8 +1103,8 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.20.12
 
-  /@babel/plugin-transform-for-of/7.18.8_@babel+core@7.20.12:
-    resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
+  /@babel/plugin-transform-for-of/7.21.0_@babel+core@7.20.12:
+    resolution: {integrity: sha512-LlUYlydgDkKpIY7mcBWvyPPmMcOphEyYA27Ef4xpbh1IiDNLr0kZsos2nf92vz3IccvJI25QUwp86Eo5s6HmBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1104,8 +1119,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-compilation-targets': 7.21.4_@babel+core@7.20.12
+      '@babel/helper-function-name': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-literals/7.18.9_@babel+core@7.20.12:
@@ -1133,19 +1148,19 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-module-transforms': 7.21.2
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/plugin-transform-modules-commonjs/7.20.11_@babel+core@7.20.12:
-    resolution: {integrity: sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==}
+  /@babel/plugin-transform-modules-commonjs/7.21.2_@babel+core@7.20.12:
+    resolution: {integrity: sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-module-transforms': 7.21.2
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
@@ -1159,7 +1174,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-module-transforms': 7.21.2
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-validator-identifier': 7.19.1
     transitivePeerDependencies:
@@ -1172,7 +1187,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-module-transforms': 7.21.2
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -1208,8 +1223,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/plugin-transform-parameters/7.20.7_@babel+core@7.12.9:
-    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
+  /@babel/plugin-transform-parameters/7.21.3_@babel+core@7.12.9:
+    resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1218,8 +1233,8 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-parameters/7.20.7_@babel+core@7.20.12:
-    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
+  /@babel/plugin-transform-parameters/7.21.3_@babel+core@7.20.12:
+    resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1273,8 +1288,8 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
-      '@babel/types': 7.20.7
+      '@babel/plugin-syntax-jsx': 7.21.4_@babel+core@7.20.12
+      '@babel/types': 7.21.4
 
   /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
@@ -1367,14 +1382,15 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-typescript/7.20.13_@babel+core@7.20.12:
-    resolution: {integrity: sha512-O7I/THxarGcDZxkgWKMUrk7NK1/WbHAg3Xx86gqS6x9MTrNL6AwIluuZ96ms4xeDe6AVx6rjHbWHP7x26EPQBA==}
+  /@babel/plugin-transform-typescript/7.21.3_@babel+core@7.20.12:
+    resolution: {integrity: sha512-RQxPz6Iqt8T0uw/WsJNReuBpWpBqs/n7mNo18sKLoTbMp+UrEekhH+pKSVC7gWz+DNjo9gryfV8YzCiT45RgMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.12
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-create-class-features-plugin': 7.21.4_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
     transitivePeerDependencies:
@@ -1399,22 +1415,22 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/preset-env/7.20.2_@babel+core@7.20.12:
-    resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
+  /@babel/preset-env/7.21.4_@babel+core@7.20.12:
+    resolution: {integrity: sha512-2W57zHs2yDLm6GD5ZpvNn71lZ0B/iypSdIeq25OurDKji6AdzV07qp4s3n1/x5BqtiGaTrPN3nerlSCaC5qNTw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.21.4
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/helper-compilation-targets': 7.21.4_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.18.6
+      '@babel/helper-validator-option': 7.21.0
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7_@babel+core@7.20.12
       '@babel/plugin-proposal-async-generator-functions': 7.20.7_@babel+core@7.20.12
       '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-class-static-block': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-proposal-class-static-block': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.20.12
       '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.20.12
@@ -1423,9 +1439,9 @@ packages:
       '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.20.12
       '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-private-property-in-object': 7.20.5_@babel+core@7.20.12
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.20.12
       '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.20.12
@@ -1445,25 +1461,25 @@ packages:
       '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.20.12
       '@babel/plugin-transform-async-to-generator': 7.20.7_@babel+core@7.20.12
       '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-block-scoping': 7.20.15_@babel+core@7.20.12
-      '@babel/plugin-transform-classes': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-transform-block-scoping': 7.21.0_@babel+core@7.20.12
+      '@babel/plugin-transform-classes': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-transform-computed-properties': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-destructuring': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-transform-destructuring': 7.21.3_@babel+core@7.20.12
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.20.12
       '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.20.12
+      '@babel/plugin-transform-for-of': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.20.12
       '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.20.12
       '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-modules-amd': 7.20.11_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-commonjs': 7.20.11_@babel+core@7.20.12
+      '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.20.12
       '@babel/plugin-transform-modules-systemjs': 7.20.11_@babel+core@7.20.12
       '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5_@babel+core@7.20.12
       '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-transform-parameters': 7.21.3_@babel+core@7.20.12
       '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-regenerator': 7.20.5_@babel+core@7.20.12
       '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.20.12
@@ -1475,7 +1491,7 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.20.12
       '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.20.12
       '@babel/preset-modules': 0.1.5_@babel+core@7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
       babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.20.12
       babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.20.12
       babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.20.12
@@ -1492,7 +1508,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.18.6
+      '@babel/helper-validator-option': 7.21.0
       '@babel/plugin-transform-flow-strip-types': 7.19.0_@babel+core@7.20.12
     dev: true
 
@@ -1505,7 +1521,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
       esutils: 2.0.3
 
   /@babel/preset-react/7.18.6_@babel+core@7.20.12:
@@ -1516,22 +1532,24 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.18.6
+      '@babel/helper-validator-option': 7.21.0
       '@babel/plugin-transform-react-display-name': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.20.12
       '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-react-pure-annotations': 7.18.6_@babel+core@7.20.12
 
-  /@babel/preset-typescript/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
+  /@babel/preset-typescript/7.21.4_@babel+core@7.20.12:
+    resolution: {integrity: sha512-sMLNWY37TCdRH/bJ6ZeeOH1nPuanED7Ai9Y/vH31IPqalioJ6ZNFUWONsakhv4r4n+I6gm5lmoE0olkgib/j/A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-typescript': 7.20.13_@babel+core@7.20.12
+      '@babel/helper-validator-option': 7.21.0
+      '@babel/plugin-syntax-jsx': 7.21.4_@babel+core@7.20.12
+      '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.20.12
+      '@babel/plugin-transform-typescript': 7.21.3_@babel+core@7.20.12
     transitivePeerDependencies:
       - supports-color
 
@@ -1574,22 +1592,22 @@ packages:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.20.15
-      '@babel/types': 7.20.7
+      '@babel/code-frame': 7.21.4
+      '@babel/parser': 7.21.4
+      '@babel/types': 7.21.4
 
-  /@babel/traverse/7.20.13:
-    resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
+  /@babel/traverse/7.21.4:
+    resolution: {integrity: sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
+      '@babel/code-frame': 7.21.4
+      '@babel/generator': 7.21.4
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.15
-      '@babel/types': 7.20.7
+      '@babel/parser': 7.21.4
+      '@babel/types': 7.21.4
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -1597,6 +1615,14 @@ packages:
 
   /@babel/types/7.20.7:
     resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.19.4
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+
+  /@babel/types/7.21.4:
+    resolution: {integrity: sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
@@ -2173,8 +2199,8 @@ packages:
       '@types/yargs': 17.0.22
       chalk: 4.1.2
 
-  /@jest/types/29.4.3:
-    resolution: {integrity: sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==}
+  /@jest/types/29.5.0:
+    resolution: {integrity: sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/schemas': 29.4.3
@@ -2491,7 +2517,7 @@ packages:
     peerDependencies:
       ajv: 4.11.8 - 8
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       '@babel/runtime': 7.20.13
       '@humanwhocodes/momoa': 2.0.4
       ajv: 8.12.0
@@ -2790,7 +2816,7 @@ packages:
         optional: true
     dependencies:
       '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/preset-env': 7.21.4_@babel+core@7.20.12
       '@jest/transform': 26.6.2
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@storybook/addons': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
@@ -3289,8 +3315,8 @@ packages:
     hasBin: true
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
-      '@storybook/codemod': 6.5.16_@babel+preset-env@7.20.2
+      '@babel/preset-env': 7.21.4_@babel+core@7.20.12
+      '@storybook/codemod': 6.5.16_@babel+preset-env@7.21.4
       '@storybook/core-common': 6.5.16_4mcwwc7vwh2owdh3davfpzf4km
       '@storybook/csf-tools': 6.5.16
       '@storybook/node-logger': 6.5.16
@@ -3307,7 +3333,7 @@ packages:
       fs-extra: 9.1.0
       get-port: 5.1.1
       globby: 11.1.0
-      jscodeshift: 0.13.1_@babel+preset-env@7.20.2
+      jscodeshift: 0.13.1_@babel+preset-env@7.21.4
       json5: 2.2.3
       leven: 3.1.0
       prompts: 2.4.2
@@ -3368,10 +3394,10 @@ packages:
       core-js: 3.28.0
       global: 4.4.0
 
-  /@storybook/codemod/6.5.16_@babel+preset-env@7.20.2:
+  /@storybook/codemod/6.5.16_@babel+preset-env@7.21.4:
     resolution: {integrity: sha512-bYu0QzkWpgILFdQnbIsnICfL08Z4xmLSmL0Rq9WWGRnSnNnGzX5P57gz+fW7+NHFGxdCTCuHJPvwAXGuJQApPQ==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
       '@mdx-js/mdx': 1.6.22
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.16
@@ -3379,7 +3405,7 @@ packages:
       core-js: 3.28.0
       cross-spawn: 7.0.3
       globby: 11.1.0
-      jscodeshift: 0.13.1_@babel+preset-env@7.20.2
+      jscodeshift: 0.13.1_@babel+preset-env@7.21.4
       lodash: 4.17.21
       prettier: 2.3.0
       recast: 0.19.1
@@ -3497,21 +3523,21 @@ packages:
       '@babel/plugin-proposal-export-default-from': 7.18.10_@babel+core@7.20.12
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-private-property-in-object': 7.20.5_@babel+core@7.20.12
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.12
       '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-block-scoping': 7.20.15_@babel+core@7.20.12
-      '@babel/plugin-transform-classes': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-destructuring': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.20.12
-      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-transform-block-scoping': 7.21.0_@babel+core@7.20.12
+      '@babel/plugin-transform-classes': 7.21.0_@babel+core@7.20.12
+      '@babel/plugin-transform-destructuring': 7.21.3_@babel+core@7.20.12
+      '@babel/plugin-transform-for-of': 7.21.0_@babel+core@7.20.12
+      '@babel/plugin-transform-parameters': 7.21.3_@babel+core@7.20.12
       '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-spread': 7.20.7_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/preset-env': 7.21.4_@babel+core@7.20.12
       '@babel/preset-react': 7.18.6_@babel+core@7.20.12
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
+      '@babel/preset-typescript': 7.21.4_@babel+core@7.20.12
       '@babel/register': 7.18.9_@babel+core@7.20.12
       '@storybook/node-logger': 6.5.16
       '@storybook/semver': 7.3.2
@@ -3683,12 +3709,12 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/generator': 7.20.14
-      '@babel/parser': 7.20.15
+      '@babel/generator': 7.21.4
+      '@babel/parser': 7.21.4
       '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/preset-env': 7.21.4_@babel+core@7.20.12
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/mdx1-csf': 0.0.1_@babel+core@7.20.12
       core-js: 3.28.0
@@ -3852,10 +3878,10 @@ packages:
   /@storybook/mdx1-csf/0.0.1_@babel+core@7.20.12:
     resolution: {integrity: sha512-4biZIWWzoWlCarMZmTpqcJNgo/RBesYZwGFbQeXiGYsswuvfWARZnW9RE9aUEMZ4XPn7B1N3EKkWcdcWe/K2tg==}
     dependencies:
-      '@babel/generator': 7.20.14
-      '@babel/parser': 7.20.15
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
-      '@babel/types': 7.20.7
+      '@babel/generator': 7.21.4
+      '@babel/parser': 7.21.4
+      '@babel/preset-env': 7.21.4_@babel+core@7.20.12
+      '@babel/types': 7.21.4
       '@mdx-js/mdx': 1.6.22
       '@types/lodash': 4.14.191
       js-string-escape: 1.0.1
@@ -4384,13 +4410,13 @@ packages:
     resolution: {integrity: sha512-cAaR/CAiZRB8GP32N+1jocovUtvlj0+e65TB50/6Lcime+EA49m/8l+P2ko+XPJ4dw3xaPS3jOL4F2X4KWxoeQ==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@svgr/hast-util-to-babel-ast/6.5.1:
     resolution: {integrity: sha512-1hnUxxjd83EAxbL4a0JDJoD3Dao3hmjvyvyEV8PzWmLK3B9m9NPlW7GKjFyoWE8nM7HnXzPcmmSyOW8yOddSXw==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
       entities: 4.4.0
     dev: false
 
@@ -4457,7 +4483,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/plugin-transform-react-constant-elements': 7.20.2_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/preset-env': 7.21.4_@babel+core@7.20.12
       '@babel/preset-react': 7.18.6_@babel+core@7.20.12
       '@svgr/core': 5.5.0
       '@svgr/plugin-jsx': 5.5.0
@@ -4491,7 +4517,7 @@ packages:
     resolution: {integrity: sha512-+/TLgKNFsYUshOY/zXsQOk+PlFQK+eyJ9T13IDVNJEi+M+Un7xlJK+FZKkbGSnf0+7E1G6PlDhkSYQ/GFiruBQ==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       '@babel/runtime': 7.20.13
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
@@ -4603,18 +4629,18 @@ packages:
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.20.15
-      '@babel/types': 7.20.7
+      '@babel/parser': 7.21.4
+      '@babel/types': 7.21.4
 
   /@types/babel__traverse/7.18.3:
     resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
 
   /@types/body-parser/1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
@@ -6121,7 +6147,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.4
       '@types/babel__core': 7.20.0
       '@types/babel__traverse': 7.18.3
 
@@ -6149,7 +6175,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.21.4
       '@babel/core': 7.20.12
       '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.12
       semver: 6.3.0
@@ -6239,15 +6265,15 @@ packages:
       '@babel/plugin-proposal-decorators': 7.20.13_@babel+core@7.20.12
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-private-property-in-object': 7.20.5_@babel+core@7.20.12
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-transform-flow-strip-types': 7.19.0_@babel+core@7.20.12
       '@babel/plugin-transform-react-display-name': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-runtime': 7.19.6_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/preset-env': 7.21.4_@babel+core@7.20.12
       '@babel/preset-react': 7.18.6_@babel+core@7.20.12
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
+      '@babel/preset-typescript': 7.21.4_@babel+core@7.20.12
       '@babel/runtime': 7.20.13
       babel-plugin-macros: 3.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -9043,8 +9069,8 @@ packages:
     resolution: {integrity: sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
       c8: 7.13.0
     transitivePeerDependencies:
       - supports-color
@@ -9539,7 +9565,7 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       chalk: 2.4.2
       eslint: 8.28.0
       micromatch: 3.1.10
@@ -9567,7 +9593,7 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       '@types/json-schema': 7.0.11
       chalk: 4.1.2
       chokidar: 3.5.3
@@ -9599,7 +9625,7 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       '@types/json-schema': 7.0.11
       chalk: 4.1.2
       chokidar: 3.5.3
@@ -9712,7 +9738,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
@@ -11132,7 +11158,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/parser': 7.20.15
+      '@babel/parser': 7.21.4
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -11430,7 +11456,7 @@ packages:
     resolution: {integrity: sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -11444,7 +11470,7 @@ packages:
     resolution: {integrity: sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       '@jest/types': 28.1.3
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -11590,10 +11616,10 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/generator': 7.20.14
+      '@babel/generator': 7.21.4
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.18.3
@@ -11648,11 +11674,11 @@ packages:
       graceful-fs: 4.2.10
       picomatch: 2.3.1
 
-  /jest-util/29.4.3:
-    resolution: {integrity: sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==}
+  /jest-util/29.5.0:
+    resolution: {integrity: sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       '@types/node': 16.18.3
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -11740,7 +11766,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@types/node': 16.18.3
-      jest-util: 29.4.3
+      jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -11806,21 +11832,21 @@ packages:
     dependencies:
       argparse: 2.0.1
 
-  /jscodeshift/0.13.1_@babel+preset-env@7.20.2:
+  /jscodeshift/0.13.1_@babel+preset-env@7.21.4:
     resolution: {integrity: sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==}
     hasBin: true
     peerDependencies:
       '@babel/preset-env': ^7.1.6
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/parser': 7.20.15
+      '@babel/parser': 7.21.4
       '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-commonjs': 7.20.11_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.20.12
+      '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.20.12
+      '@babel/preset-env': 7.21.4_@babel+core@7.20.12
       '@babel/preset-flow': 7.18.6_@babel+core@7.20.12
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
+      '@babel/preset-typescript': 7.21.4_@babel+core@7.20.12
       '@babel/register': 7.18.9_@babel+core@7.20.12
       babel-core: 7.0.0-bridge.0_@babel+core@7.20.12
       chalk: 4.1.2
@@ -13639,7 +13665,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -15016,7 +15042,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       address: 1.2.2
       browserslist: 4.21.5
       chalk: 4.1.2
@@ -15061,7 +15087,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/generator': 7.20.14
+      '@babel/generator': 7.21.4
       '@babel/runtime': 7.20.13
       ast-types: 0.14.2
       commander: 2.20.3
@@ -15771,7 +15797,7 @@ packages:
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       jest-worker: 26.6.2
       rollup: 2.79.1
       serialize-javascript: 4.0.0
@@ -18372,7 +18398,7 @@ packages:
     dependencies:
       '@apideck/better-ajv-errors': 0.3.6_ajv@8.12.0
       '@babel/core': 7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/preset-env': 7.21.4_@babel+core@7.20.12
       '@babel/runtime': 7.20.13
       '@rollup/plugin-babel': 5.3.1_3dsfpkpoyvuuxyfgdbpn4j4uzm
       '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.1


### PR DESCRIPTION
TL/DR
This story involves creating a top-level component TrendingSuggestions that fetches and handles data from MSW using Axios and React Query. 

Overview of Changes

`TrendingSuggestions.tsx`
- Use RQ to handle incoming `trending-suggestions` data 
- Add parameter `{ staleTime: Infinity }` to avoid re-fetching when users refocus the window
- Import & render `TrendingSuggestionList` component with it's appropriate props.

`TrendingSuggestions.api.ts`
- Created function to fetch mock data via an axios get request

`TrendingSuggestions.test.tsx`
- Wrote test to ensure our data is being rendered once the fetch completes.
- Add RQ / MSW functionality to the test

`mockServer.ts`
- add MSW server for global imports

`apps/web/package.json`
- Add moduleNameMapper to enable jest to interact with ES6 imports.

`TrendingSuggestionList.tsx`
- Add export to interface to use it within `TrendingSuggestions.tsx`
- Refactor subRedditIcon to string within `metaDataItem` interface

`TrendingSuggestionList.utils.tsx`
- Remove Icon & replace typing with string

`TrendingItemSuggestion.tsx`
- Refactor interface to accept temporary string value for subRedditIcon 
- Remove Icon component (temporary)

`testSetup.tsx`
- Add global React Query provider for test components