### PR TITLE
feat: add react router to FE codebase

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^17.0.2",
     "react-query": "^3.39.3",
     "react-redux": "^8.0.5",
+    "react-router-dom": "^6.11.1",
     "react-scripts": "5.0.0",
     "redux": "^4.2.1",
     "schema-utils": "^4.0.0",

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -6,8 +6,17 @@ import reportWebVitals from './reportWebVitals';
 import { Provider } from 'react-redux';
 import { store } from './app/store';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
 const queryClient = new QueryClient();
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    errorElement: <p>There was an error loading this page, sorry!</p>,
+  },
+]);
 
 // MSW development status conditional
 if (process.env.NODE_ENV === 'development') {
@@ -19,7 +28,7 @@ ReactDOM.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <Provider store={store}>
-        <App />
+        <RouterProvider router={router} />
       </Provider>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,7 @@ importers:
       react-dom: ^17.0.2
       react-query: ^3.39.3
       react-redux: ^8.0.5
+      react-router-dom: ^6.11.1
       react-scripts: 5.0.0
       redux: ^4.2.1
       schema-utils: ^4.0.0
@@ -97,6 +98,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       react-query: 3.39.3_sfoxds7t5ydpegc3knd667wn6m
       react-redux: 8.0.5_27nnqo76gztpod7yf2ma4s6bee
+      react-router-dom: 6.11.1_sfoxds7t5ydpegc3knd667wn6m
       react-scripts: 5.0.0_nscezoq4ovbipqvy34j76tzjli
       redux: 4.2.1
       schema-utils: 4.0.0
@@ -2571,6 +2573,11 @@ packages:
       redux: 4.2.1
       redux-thunk: 2.4.2_redux@4.2.1
       reselect: 4.1.7
+    dev: false
+
+  /@remix-run/router/1.6.1:
+    resolution: {integrity: sha512-YUkWj+xs0oOzBe74OgErsuR3wVn+efrFhXBWrit50kOiED+pvQe2r6MWY0iJMQU/mSVKxvNzL4ZaYvjdX+G7ZA==}
+    engines: {node: '>=14'}
     dev: false
 
   /@rollup/plugin-babel/5.3.1_3dsfpkpoyvuuxyfgdbpn4j4uzm:
@@ -9712,7 +9719,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
@@ -15185,6 +15192,29 @@ packages:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /react-router-dom/6.11.1_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-dPC2MhoPeTQ1YUOt5uIK376SMNWbwUxYRWk2ZmTT4fZfwlOvabF8uduRKKJIyfkCZvMgiF0GSCQckmkGGijIrg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.6.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router: 6.11.1_react@17.0.2
+    dev: false
+
+  /react-router/6.11.1_react@17.0.2:
+    resolution: {integrity: sha512-OZINSdjJ2WgvAi7hgNLazrEV8SGn6xrKA+MkJe9wVDMZ3zQ6fdJocUjpCUCI0cNrelWjcvon0S/QK/j0NzL3KA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.6.1
+      react: 17.0.2
+    dev: false
 
   /react-scripts/5.0.0_nscezoq4ovbipqvy34j76tzjli:
     resolution: {integrity: sha512-3i0L2CyIlROz7mxETEdfif6Sfhh9Lfpzi10CtcGs1emDQStmZfWjJbAIMtRD0opVUjQuFWqHZyRZ9PPzKCFxWg==}


### PR DESCRIPTION
# TL/DR
This PR adds React Router to the Web App and configures the base path using the `App` component.

## Overview of Changes
`package.json` & `pnpm-lock.yaml`

- install `react-router-dom` dependency for the web folder

`index.tsx`

- Implement base path `'/'` with the element `<App />` using react router

